### PR TITLE
Auto-resize canvas after FB init.

### DIFF
--- a/views/helpers/facebook.php
+++ b/views/helpers/facebook.php
@@ -393,7 +393,7 @@ class FacebookHelper extends AppHelper {
 	* @example $this->Facebook->init();
 	* @return string of scriptBlock for FB.init() or error
 	*/
-	function init($options = null, $reload = true) {
+	function init($options = null, $reload = true, $FBCanvasSetSize = false) {
 		if (empty($options)) {
 			$options = array();
 		}
@@ -404,6 +404,11 @@ class FacebookHelper extends AppHelper {
 			} else {
 				$callback = "if(typeof(facebookReady)=='function'){facebookReady()}";
 			}
+
+            if ($FBCanvasSetSize) {
+                $callback = "FB.Canvas.setSize();";
+            }
+
 			$init = '<div id="fb-root"></div>';
 			$init .= $this->Html->scriptBlock(
 <<<JS


### PR DESCRIPTION
Adding an optional FB.Canvas.setSize() at the end of $facebook->init helper method.
