### PR TITLE
Updated logout helper

### DIFF
--- a/views/helpers/facebook.php
+++ b/views/helpers/facebook.php
@@ -135,7 +135,7 @@ class FacebookHelper extends AppHelper {
 	* - redirect string to your app's logout url (default null)
 	* - label string of text to use in link (default logout)
 	* - confirm string Alert dialog which will be visible if user clicks on the button/link
-	* - custom used to create custom link instead of standart fbml. if redirect option is set this one is not required.
+	* - custom used to create custom link instead of standard fbml. if redirect option is set this one is not required.
 	* @param string label
 	* @return string XFBML tag for logout button
 	* @access public
@@ -159,6 +159,9 @@ class FacebookHelper extends AppHelper {
 			$onclick = "FB.logout(function(response){".$response."});";
 			if(isset($options['confirm'])){
 				$onclick = 'if(confirm("'.$options['confirm'].'")){'.$onclick.'}';
+			}
+			if(!empty($label)){
+				$options['label'] = $label;
 			}
 			return $this->Html->link($options['label'], '#', array('onclick' => $onclick));
 		} else {


### PR DESCRIPTION
This is the first time I've ever issued a pull request, so I apologize in advance if I've made any egregious errors in protocol.  The update I made was very simple.  The logout helper accepts a label as the second parameter, but when you specify a redirect in the options array it is ignored and the default 'logout' text.  I know that you can specify it by setting the label in the options array as well, but I figured allowing the user to do it either way wouldn't be a bad thing.  I also fixed one minor typo in the comments for that helper.
