### PR TITLE
Facebook::__construct() call session_start() before CakeSession 1.3

### DIFF
--- a/controllers/components/connect.php
+++ b/controllers/components/connect.php
@@ -60,6 +60,9 @@ class ConnectComponent extends Object {
 	*/
 	function initialize(&$Controller, $settings = array()){
 		$this->Controller = $Controller;
+        if (!$this->Controller->Session->started()) {
+            $this->Controller->Session->start();
+        }
 		$this->_set($settings);
 		$this->FB = new FB();
 		$this->uid = $this->FB->getUser();


### PR DESCRIPTION
Fix to stop Facebook SDK starting session outside of session component, because of CakePHP1.3 starts session in SessionComponent::startup() after Components::initialize and Controller::beforeFilter() in Controller::startupProcess.
