### PR TITLE
The constructor of view expects the first parameter to be a view

### DIFF
--- a/views/helpers/facebook.php
+++ b/views/helpers/facebook.php
@@ -31,7 +31,7 @@ class FacebookHelper extends AppHelper {
 	* Loadable construct, pass in locale settings
 	* Fail safe locale to 'en_US'
 	*/
-	function __construct($settings = array()){
+	function __construct(View $View, $settings = array()){
 		$this->_set($settings);
 		
 		if(!$this->locale){
@@ -40,7 +40,7 @@ class FacebookHelper extends AppHelper {
 		if(!$this->locale){
 			$this->locale = 'en_US';
 		}
-		parent::__construct();
+		parent::__construct($View, $settings);
 	}
 	
 	/**


### PR DESCRIPTION
Hello,

this patch corrects some warnings after include the facebook helper.

Correcting the constructor of the helper +
passing the parameters to the parent constructor

HTH,
Daniel
