### PR TITLE
Handle two issues 

### DIFF
--- a/Controller/Component/ConnectComponent.php
+++ b/Controller/Component/ConnectComponent.php
@@ -172,7 +172,8 @@ class ConnectComponent extends Component {
 						'fields' => array('username' => 'facebook_id', 'password' => $this->modelFields['password'])
 					)
 				);
-				if($Auth->login($this->authUser[$this->model])){
+				list($plugin, $class) = pluginSplit($this->model, true);
+				if($Auth->login($this->authUser[$class])){
 					$this->__runCallback('afterFacebookLogin');
 				}
 			}

--- a/View/Helper/FacebookHelper.php
+++ b/View/Helper/FacebookHelper.php
@@ -553,13 +553,18 @@ class FacebookHelper extends AppHelper {
 
 	// logs the user out of the application and facebook
 	function logout(redirection){
-		FB.logout(function(response) {
-			// user is logged out
-			// redirection if any
-			if(redirection != null && redirection != ''){
-				top.location.href = redirection;
-			}
-		});
+		if (FB.getAuthResponse()) {
+			FB.logout(function(response) {
+	            // user is logged out
+	            // redirection if any
+	            if(redirection != null && redirection != ''){
+	                top.location.href = redirection;
+	            }
+	        });} else {
+		    if(redirection != null && redirection != ''){
+                    	top.location.href = redirection;
+               	    }
+	        };
 	}
 
 	// Load the SDK Asynchronously


### PR DESCRIPTION
1. If Facebook is logout from same browser but different tab. the Facebook logout button will not redirect to application's logout action. This is solved by my fix.

2.It should handle the case where User model is inside a plugin. e.g.
'Facebook.Connect' => array('model' => 'Cakeuser.User').
My fix will make this work.
