### PR TITLE
Login Permissions

### DIFF
--- a/View/Helper/FacebookHelper.php
+++ b/View/Helper/FacebookHelper.php
@@ -496,6 +496,9 @@ class FacebookHelper extends AppHelper {
 			$options = array();
 		}
 		if ($appId = FacebookInfo::getConfig('appId')) {
+			if ($options['perms'] == null)
+				$options['perms'] = 'email';
+			
 			$init = '<div id="fb-root"></div>';
 			$init .= '<script src="//connect.facebook.net/en_US/all.js"></script>';
 			$init .= $this->Html->scriptBlock("
@@ -548,7 +551,7 @@ class FacebookHelper extends AppHelper {
 				// user could not log in
 				console.log('User cancelled login or did not fully authorize.');
 			}
-		}, {scope: 'email'});
+		}, {scope: '" . $options['perms'] . "'});
 	}
 
 	// logs the user out of the application and facebook


### PR DESCRIPTION
Hi there,

I noticed that passing perms to the login method does not do actually anything when you call init() afterwards (the scope in the fb JS is never changed). I changed that by passing the perms to init instead. Perhaps it'd better to keep the perms in login, set them privately in the class and have init() reusing them when called. I can do that if you don't like the approach of this patch.

Thanks for your work! 

Br,
Moises
