### PR TITLE
[Fix] array_merge() warning in FacebookHelper.php

### DIFF
--- a/View/Helper/FacebookHelper.php
+++ b/View/Helper/FacebookHelper.php
@@ -494,7 +494,7 @@ class FacebookHelper extends AppHelper {
 	public function init($options = null, $reload = true) {
 		$options = array_merge(array(
 			'perms' => 'email'
-		), $options);
+		), (array)$options);
 		if ($appId = FacebookInfo::getConfig('appId')) {
 			$init = '<div id="fb-root"></div>';
 			$init .= '<script src="//connect.facebook.net/en_US/all.js"></script>';


### PR DESCRIPTION
This simple cast should fix the:
Warning (2): array_merge(): Argument #2 is not an array [APP/Plugin/Facebook/View/Helper/FacebookHelper.php, line 497]

that i'm getting when calling
<?php echo $this->Facebook->init(); ?>
