### PR TITLE
Changing to works properly PHP 5.3 >

### DIFF
--- a/Controller/Component/ConnectComponent.php
+++ b/Controller/Component/ConnectComponent.php
@@ -220,7 +220,7 @@ class ConnectComponent extends Component {
 	* @return mixed result of the callback function
 	*/ 
 	private function __runCallback($callback, $passedIn = null){
-		if(is_callable(array($this->Controller, $callback))){
+		if(method_exists($this->Controller, $callback)){
 			return call_user_func_array(array($this->Controller, $callback), array($passedIn));
 		}
 		return true;


### PR DESCRIPTION
I was using the plugin in PHP 5.4 and the callbacks seems to not be working the reason was because the check is_callable, so i changed it to method_exists and it should work properly with the new versions of PHP

That issue was also mentioned in the issues #99
