### PR TITLE
Update Lib/FB.php (quick fix for issue #48)

### DIFF
--- a/Lib/FB.php
+++ b/Lib/FB.php
@@ -18,9 +18,16 @@ class FB {
   public static $Facebook = null;
   
   public function __construct() {
-    if (empty(self::$Facebook)) {
-			self::$Facebook = new Facebook(FacebookInfo::getConfig());
-		}
+    $this->__initInstance();
+  }
+  
+  /**
+   * Initialize a new instance if none exists
+   */
+  private function __initInstance() {
+  	if (empty(self::$Facebook)) {
+		self::$Facebook = new Facebook(FacebookInfo::getConfig());
+  	}
   }
   
   /**
@@ -53,8 +60,11 @@ class FB {
     * Example:
     * - FB::getUser();
     */
-  public static function __callstatic($method, $params){
+  public static function __callstatic($method, $params){  	
   	try {
+  		if (empty(self::$Facebook) {
+  			$this->__initInstance();
+  		}
   		return call_user_func_array(array(self::$Facebook, $method), $params);
   	} catch (FacebookApiException $e) {
 	    error_log($e);


### PR DESCRIPTION
When not using 'Facebook.Connect' in $components var the self::$Facebook static variable is not set.
This cause a warning on call_user_func and result of a non working plugin.

Being new to cakephp I only see this fix for now. This fix issue #48
