### PR TITLE
Remove synchronous loading of all.js 

### DIFF
--- a/View/Helper/FacebookHelper.php
+++ b/View/Helper/FacebookHelper.php
@@ -497,7 +497,6 @@ class FacebookHelper extends AppHelper {
 		), (array)$options);
 		if ($appId = FacebookInfo::getConfig('appId')) {
 			$init = '<div id="fb-root"></div>';
-			$init .= '<script src="//connect.facebook.net/'.$this->locale.'/all.js"></script>';
 			$init .= $this->Html->scriptBlock("
 	window.fbAsyncInit = function() {
 		FB.init({


### PR DESCRIPTION
The init() helper inserts the exact same all.js script tag twice, first synchronously and then asynchronously. I can't think of any good reason to do that, and the synchronous tag often causes a lengthy delay before the page loads. So I removed that line.
