### PR TITLE
Multiple users on same browser kept previous session + last base_facebook.php mod

### DIFF
--- a/Controller/Component/ConnectComponent.php
+++ b/Controller/Component/ConnectComponent.php
@@ -142,8 +142,8 @@ class ConnectComponent extends Component {
 		}
 		
 		// check if the user already has an account
-		// User is logged in but doesn't have a 
-		if($Auth->user('id')){
+		// User is logged in but doesn't have a
+		if($Auth->user('id') && $Auth->user('facebook_id') == $this->uid){
 			$this->hasAccount = true;
 			$this->User->id = $Auth->user($this->User->primaryKey);
 			if (!$this->User->field('facebook_id')) {
@@ -192,7 +192,7 @@ class ConnectComponent extends Component {
 	*/
 	public function user($field = null){
 		if(isset($this->uid)){
-			if($this->Controller->Session->read('FB.Me') == null){
+			if($this->Controller->Session->read('FB.Me') == null || $this->Controller->Session->read('FB.Me.id') != $this->uid){
 				$this->Controller->Session->write('FB.Me', $this->FB->api('/me'));
 			}
 			$this->me = $this->Controller->Session->read('FB.Me');


### PR DESCRIPTION
Corrected continuous session behavior when multiple users on the same browser logged in and out.

New user where keeping the session of the previous logged in user because behavior was set only to check existence of Session key.
Now refresh the Auth and FB session in case of difference between $this->uid and session *.id .

Added last mod made to base_facebook.php by Facebook - 2013-05-02
