### PR TITLE
Issue with session_start()

### DIFF
--- a/Vendor/Facebook.php
+++ b/Vendor/Facebook.php
@@ -46,7 +46,7 @@ class Facebook extends BaseFacebook
    */
   public function __construct($config) {
     if (!session_id()) {
-      session_start();
+      CakeSession::start();
     }
     parent::__construct($config);
     if (!empty($config['sharedSession'])) {


### PR DESCRIPTION
When session_start() and test SessionComponent::valid() on AppController, the session trow a error "Config doesn't exists".

On using CakeSession::start(), CakePHP create and read your own config.
