### PR TITLE
Custom cookie name is configurable now.

### DIFF
--- a/Vendor/Facebook.php
+++ b/Vendor/Facebook.php
@@ -45,6 +45,9 @@ class Facebook extends BaseFacebook
    * @see BaseFacebook::__construct in facebook.php
    */
   public function __construct($config) {
+    if (Configure::read('Session.cookie')) {
+      session_name(Configure::read('Session.cookie'));
+    }
     if (!session_id()) {
       session_start();
     }


### PR DESCRIPTION
The plugin originally would just use PHP's name. This is useful for having multiple applications on the same domain. It should work like this anyway AFAIK.
