### PR TITLE
Updates for compatibility with v2.4

### DIFF
--- a/Controller/Component/ConnectComponent.php
+++ b/Controller/Component/ConnectComponent.php
@@ -161,7 +161,7 @@ class ConnectComponent extends Component {
 			//create the user if we don't have one
 			elseif(empty($this->authUser) && $this->createUser) {
 				$this->authUser[$this->User->alias]['facebook_id'] = $this->uid;
-				$this->authUser[$this->User->alias][$this->modelFields['password']] = $Auth->password(FacebookInfo::randPass());
+				$this->authUser[$this->User->alias][$this->modelFields['password']] = Security::hash(FacebookInfo::randPass());
 				if($this->__runCallback('beforeFacebookSave')){
 					$this->hasAccount = ($this->User->save($this->authUser, array('validate' => false)));
 				}


### PR DESCRIPTION
The AuthComponent::password is being deprecated and calling it causes errors if you use 'blowfish' as Security::$hashType. If it needs to be a specific hash then it should be passed in as a second parameter
